### PR TITLE
added support for include and contains functions

### DIFF
--- a/examples/expression.tf
+++ b/examples/expression.tf
@@ -3,7 +3,9 @@ module "group_rule" {
   user_conditions = [
     { organization = "uw", division = "Customer Services" },
     { organization = "uw", division = "IT", department = "Support" },
-    { roleID = 2, isManager = true },
+    { roleID = 2, isManager = true, isTemp = false },
+    { tags_includes = "devs" },
+    { teams_contains = "infra" },
   ]
 }
 
@@ -12,8 +14,10 @@ output "group_rule" {
 }
 
 # Outputs:
-#  group_rule = <<-EOT
-#       (user.organization == "uw" && user.division == "Customer Services") ||
-#       (user.organization == "uw" && user.division == "IT" && user.department == "Support") ||
-#       (user.roleID == "2" && user.isManager == true)
-#  EOT
+# group_rule = <<EOT
+# (user.organization == "uw" && user.division == "Customer Services") ||
+# (user.organization == "uw" && user.division == "IT" && user.department == "Support") ||
+# (user.roleID == "2" && !user.isTemp && user.isManager) ||
+# (Arrays.contains(user.tags, "devs")) ||
+# (String.stringContains(user.teams, "infra"))
+# EOT

--- a/expression/main.tf
+++ b/expression/main.tf
@@ -15,19 +15,19 @@ locals {
 %{if condition[k] == "true"}
   user.${k}
 %{else}
-%{if condition[k] == "false"}
-  !user.${k}
-%{else}
-%{if length(regexall("_includes", "${k}")) > 0}
-  Arrays.contains(user.${trimsuffix(k, "_includes")}, "${condition[k]}")
-%{else}
-%{if length(regexall("_contains", "${k}")) > 0}
-  String.stringContains(user.${trimsuffix(k, "_contains")}, "${condition[k]}")
-%{else}
-  ${format("user.%s == \"%s\"", k, "${condition[k]}")}
-%{endif}
-%{endif}
-%{endif}
+  %{if condition[k] == "false"}
+    !user.${k}
+  %{else}
+    %{if length(regexall("_includes", "${k}")) > 0}
+      Arrays.contains(user.${trimsuffix(k, "_includes")}, "${condition[k]}")
+    %{else}
+      %{if length(regexall("_contains", "${k}")) > 0}
+        String.stringContains(user.${trimsuffix(k, "_contains")}, "${condition[k]}")
+      %{else}
+        ${format("user.%s == \"%s\"", k, "${condition[k]}")}
+      %{endif}
+    %{endif}
+  %{endif}
 %{endif}
 EOT
       )

--- a/expression/main.tf
+++ b/expression/main.tf
@@ -1,34 +1,54 @@
 locals {
   # input
   # user_conditions = [
-  #   {
-  #     AK1 = "AV1"
-  #     AK2 = 2
-  #   },
-  #   {
-  #     BK1 = "BV1"
-  #     BK2 = false
-  #   }
+  # { AK1 = "AV1", AK2 = 2 },
+  # { BK1 = "BV1", BK2 = false },
+  # { CK1_includes = "CV1", CK2 = true },
+  # { DK1_contains = "DV1" }
   # ]
 
   attributeStrs = [
     for condition in var.user_conditions : [
       # reverse key to get attributes in order of organisation,division,department
       for k in reverse(keys(condition)) :
-      format("user.%s == %s", k,
-        "%{if condition[k] == "true" || condition[k] == "false"}${condition[k]}%{else}\"${condition[k]}\"%{endif}"
+      trimspace(<<EOT
+%{if condition[k] == "true"}
+  user.${k}
+%{else}
+%{if condition[k] == "false"}
+  !user.${k}
+%{else}
+%{if length(regexall("_includes", "${k}")) > 0}
+  Arrays.contains(user.${trimsuffix(k, "_includes")}, "${condition[k]}")
+%{else}
+%{if length(regexall("_contains", "${k}")) > 0}
+  String.stringContains(user.${trimsuffix(k, "_contains")}, "${condition[k]}")
+%{else}
+  ${format("user.%s == \"%s\"", k, "${condition[k]}")}
+%{endif}
+%{endif}
+%{endif}
+%{endif}
+EOT
       )
     ]
   ]
   # attributeStrs = [
-  #  [
-  #    "user.AK1 == \"AV1\"",
-  #    "user.AK2 == \"2\"",
-  #  ],
-  #  [
-  #    "user.BK1 == \"BV1\"",
-  #    "user.BK2 == false",
-  #  ],
+  #   [
+  #     "user.AK2 == \"2\"",
+  #     "user.AK1 == \"AV1\"",
+  #   ],
+  #   [
+  #     "!user.BK2",
+  #     "user.BK1 == \"BV1\"",
+  #   ],
+  #   [
+  #     "user.CK2",
+  #     "Arrays.contains(user.CK1, \"CV1\")",
+  #   ],
+  #   [
+  #     "String.stringContains(user.DK1, \"DV1\")",
+  #   ],
   # ]
 
   paths = [
@@ -37,12 +57,16 @@ locals {
   ]
   # paths = [
   #   "(user.AK2 == \"2\" && user.AK1 == \"AV1\")",
-  #   "(user.BK2 == false && user.BK1 == \"BV1\")",
+  #   "(!user.BK2 && user.BK1 == \"BV1\")",
+  #   "(user.CK2 && Arrays.contains(user.CK1, \"CV1\"))",
+  #   "(String.stringContains(user.DK1, \"DV1\"))",
   # ]
 
   expression = join(" ||\n", local.paths)
   # expression = <<EOT
-  # (user.AK2 == "2" && user.AK1 == "AV1") ||
-  # (user.BK2 == false && user.BK1 == "BV1")
+  #  (user.AK2 == "2" && user.AK1 == "AV1") ||
+  #  (!user.BK2 && user.BK1 == "BV1") ||
+  #  (user.CK2 && Arrays.contains(user.CK1, "CV1")) ||
+  #  (String.stringContains(user.DK1, "DV1"))
   # EOT
 }


### PR DESCRIPTION
added   `_includes` and `_contains` operator which can be suffixed to the `key` name.
for these suffixed keys module will use okta `Arrays` and `Strings` function instead of `==` as shown..

`tags_includes = "contractor"` will be converted to `Arrays.contains(user.tags, "contractor")`

`teams_contains = "infra"` will be converted to `String.stringContains(user.teams, "infra")`

without suffix 
`teams = "infra"` will be converted to `user.teams == "infra"`