### PR TITLE
Add starts_with operator

### DIFF
--- a/examples/expression.tf
+++ b/examples/expression.tf
@@ -10,6 +10,7 @@ module "group_rule" {
       { roleID = 2, isManager = true, isTemp = false },
       { tags_includes = "devs" },
       { teams_contains = "infra" },
+      { teams_starts_with = "Technology/Security" }
     ]
   ]
 }

--- a/expression/README.md
+++ b/expression/README.md
@@ -20,12 +20,14 @@ joined using OR(||) operator. groups are then joined using `&&` operator.
 * `expression` : The expression is the string containing generated okta expression based on `user_conditions`.
 
 ### operator:
-module supports `_includes` and `_contains` operator which can be suffixed to the `key` name.
+module supports `_includes`, `_contains` and `_starts_with` operator which can be suffixed to the `key` name.
 for these suffixed keys module will use okta `Arrays` and `Strings` function instead of `==` as shown..
 
 `tags_includes = "contractor"` will be converted to `Arrays.contains(user.tags, "contractor")`
 
 `teams_contains = "infra"` will be converted to `String.stringContains(user.teams, "infra")`
+
+`teams_starts_with = "Technology/Security"` will be converted to `String.startsWith(user.teams, "Technology/Security")`
 
 ### Example:
 ```hcl
@@ -41,6 +43,7 @@ module "group_rule" {
       { roleID = 2, isManager = true, isTemp = false },
       { tags_includes = "devs" },
       { teams_contains = "infra" },
+      { teams_starts_with = "Technology/Security" },
     ]
   ]
 }

--- a/expression/main.tf
+++ b/expression/main.tf
@@ -9,7 +9,8 @@ locals {
   #     { AK1 = "AV1", AK2 = 2 },
   #     { BK1 = "BV1", BK2 = false },
   #     { CK1_includes = "CV1", CK2 = true },
-  #     { DK1_contains = "DV1" }
+  #     { DK1_contains = "DV1" },
+  #     { EK1_starts_with = "EV1" }
   #   ]
   # ]
 
@@ -31,7 +32,11 @@ locals {
       %{if length(regexall("_contains", "${k}")) > 0}
         String.stringContains(user.${trimsuffix(k, "_contains")}, "${condition[k]}")
       %{else}
-        ${format("user.%s == \"%s\"", k, "${condition[k]}")}
+        %{if length(regexall("_starts_with", "${k}")) > 0}
+          String.startsWith(user.${trimsuffix(k, "_starts_with")}, "${condition[k]}")
+        %{else}
+          ${format("user.%s == \"%s\"", k, "${condition[k]}")}
+        %{endif}
       %{endif}
     %{endif}
   %{endif}

--- a/group/README.md
+++ b/group/README.md
@@ -56,6 +56,7 @@ module "app_access_with_condition" {
       { roleID = 2, isManager = true, isTemp = false },
       { tags_includes = "devs" },
       { teams_contains = "infra" },
+      { teams_starts_with = "Technology/Security" },
     ]
   ]
 }


### PR DESCRIPTION
Allow checking that a string field has the required prefix.

An example is making sure that a team filter is always checking from the root path.